### PR TITLE
Fixes #2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,11 @@
 .vscode/
 *__pycache__/
 .python-version
+
 ref/
 stash/
 
 *.egg-info/
 dist/
+
+.tox/

--- a/tenscalc/__main__.py
+++ b/tenscalc/__main__.py
@@ -11,6 +11,8 @@
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 
+"""Interface for calling cli with ``python -m ...``."""
+
 from tenscalc.cli import main
 
 main()

--- a/tenscalc/cli.py
+++ b/tenscalc/cli.py
@@ -93,8 +93,8 @@ def main(args: list[str] = None):
     """Command line interface for tenscalc.
 
     Args:
-        args (list[str], optional): Argument list. The default of ``None``
-        will read sys.argv
+        args (list[str], optional): Argument list. The default of
+            ``None`` will read sys.argv
     """
     parsed_args = parser.parse_args(args)
 

--- a/tenscalc/tenscalc.py
+++ b/tenscalc/tenscalc.py
@@ -75,7 +75,7 @@ _err_msg = {
 
 
 def print_material_codes(padding=0):
-    """Print valid string material codes and corresponding descriptions."""
+    """Print valid string material codes and descriptions."""
     just = 4 + padding
     print('code'.rjust(just), 'material', sep='  ',)
     print('----'.rjust(just), '--------', sep='  ')

--- a/tenscalc/tenscalc.py
+++ b/tenscalc/tenscalc.py
@@ -200,8 +200,8 @@ class StringSet:
             of differing length.
     """
 
-    def __init__(self, length: float, gauges: list[float],
-                 materials: list[str], pitches: list[str],
+    def __init__(self, length: float, gauges: list,
+                 materials: list, pitches: list,
                  double=False, si=False):
         """Class constructor."""
         try:

--- a/tox.ini
+++ b/tox.ini
@@ -3,6 +3,10 @@ envlist = py37,py38,py39,py310
 
 [testenv]
 deps = 
+    pycodestyle
+    pydocstyle
     pytest
 commands = 
+    - pycodestyle --max-doc-length=72 tenscalc/
+    - pydocstyle --convention=google tenscalc/
     pytest

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,8 @@
+[tox]
+envlist = py37,py38,py39,py310
+
+[testenv]
+deps = 
+    pytest
+commands = 
+    pytest


### PR DESCRIPTION
Fixes #2 by changing `list[str]` type hinting to `list`, which allows support for (at least) Python >= 3.7.